### PR TITLE
Call db_create on startup

### DIFF
--- a/lavapdu/dbhandler.py
+++ b/lavapdu/dbhandler.py
@@ -33,6 +33,7 @@ class DBHandler(object):
                                      password=config["dbpass"],
                                      host=config["dbhost"])
         self.cursor = self.conn.cursor()
+        self.create_db()
 
     def do_sql(self, sql):
         log.debug("executing sql: %s", sql)


### PR DESCRIPTION
dbhandler now calls db_create on startup. This allows for cleaner bringup when
either starting up and the db table does not yet exist, or is outdated.