### PR TITLE
listener: Create the database on startup

### DIFF
--- a/etc/lavapdu-runner.service
+++ b/etc/lavapdu-runner.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Runner daemon to process PDU requests
-After=postgresql.service
+After=postgresql.service lavapdu-listen.service
 
 [Service]
 ExecStart=/usr/sbin/lavapdu-runner

--- a/lavapdu/socketserver.py
+++ b/lavapdu/socketserver.py
@@ -46,6 +46,7 @@ class ListenerServer(object):
         self.server.settings = settings
         self.server.config = config
         self.server.dbh = DBHandler(settings)
+        self.server.dbh.create_db()
 
     def start(self):
         log.info("Starting the ListenerServer")


### PR DESCRIPTION
The refactoring in commit d4a099820 dropped the call to create_db,
causing the pdudaemons tables to not be autocreated anymore on initial
setup.

Also order lavapdu-runner to start after listen which sets up the
database (This isn't perfect as there is no notification from -listen
that it's done startup/the database was created)
