### PR TITLE
Startup refactoring

### DIFF
--- a/etc/lavapdu-listen.service
+++ b/etc/lavapdu-listen.service
@@ -3,7 +3,7 @@ Description=TCP Listening daemon to accept PDU requests
 After=postgresql.service
 
 [Service]
-ExecStart=/usr/sbin/lavapdu-listen
+ExecStart=/usr/sbin/lavapdu-listen -j
 Type=forking
 PIDFile=/var/run/lavapdu-listen.pid
 

--- a/etc/lavapdu-runner.service
+++ b/etc/lavapdu-runner.service
@@ -3,7 +3,7 @@ Description=Runner daemon to process PDU requests
 After=postgresql.service
 
 [Service]
-ExecStart=/usr/sbin/lavapdu-runner
+ExecStart=/usr/sbin/lavapdu-runner -j
 Type=forking
 PIDFile=/var/run/lavapdu-runner.pid
 

--- a/lavapdu-listen
+++ b/lavapdu-listen
@@ -19,17 +19,9 @@
 #  MA 02110-1301, USA.
 
 import logging
-import os
-import sys
-import optparse
-from lavapdu.shared import get_daemon_logger
 from lavapdu.shared import read_settings
-
-import daemon
-try:
-    import daemon.pidlockfile as pidlockfile
-except ImportError:
-    from lockfile import pidlockfile
+from lavapdu.shared import get_common_argparser
+from lavapdu.shared import setup_daemon
 
 from lavapdu.socketserver import ListenerServer
 
@@ -38,57 +30,22 @@ if __name__ == '__main__':
     pidfile = "/var/run/lavapdu-listen.pid"
     logfile = "/var/log/lavapdu-listener.log"
     conffile = "/etc/lavapdu/lavapdu.conf"
-    settings = read_settings(conffile)
-    usage = "Usage: %prog [--logfile] --[loglevel]"
     description = "LAVA PDU request listener server," \
                   "host and port are handled in %s" % conffile
-    parser = optparse.OptionParser(usage=usage, description=description)
-    parser.add_option("--logfile", dest="logfile", action="store",
-                      type="string", help="log file [%s]" % logfile)
-    parser.add_option("--loglevel", dest="loglevel", action="store",
-                      type="string", help="logging level [INFO]")
-    parser.add_option("--purge", dest="purge", action="store_true")
-    (options, args) = parser.parse_args()
-    if options.logfile:
-        if os.path.exists(os.path.dirname(options.logfile)):
-            logfile = options.logfile
-        else:
-            print "No such directory for specified logfile '%s'" % logfile
-    open(logfile, 'w').close()
-    level = logging.DEBUG
-    daemon_settings = settings["daemon"]
-    if daemon_settings["logging_level"] == "DEBUG":
-        level = logging.DEBUG
-    if daemon_settings["logging_level"] == "WARNING":
-        level = logging.WARNING
-    if daemon_settings["logging_level"] == "ERROR":
-        level = logging.ERROR
-    if daemon_settings["logging_level"] == "INFO":
-        level = logging.INFO
-    client_logger, watched_file_handler = get_daemon_logger(
-        logfile,
-        loglevel=level,
-        log_format='%(asctime)s:%(levelname)s:%(name)s:%(message)s')
-    if isinstance(client_logger, Exception):
-        print("Fatal error creating client_logger: " + str(client_logger))
-        sys.exit(os.EX_OSERR)
-    # noinspection PyArgumentList
-    lockfile = pidlockfile.PIDLockFile(pidfile)
-    if lockfile.is_locked():
-        logging.error("PIDFile %s already locked" % pidfile)
-        sys.exit(os.EX_OSERR)
-    context = daemon.DaemonContext(
-        detach_process=True,
-        working_directory=os.getcwd(),
-        pidfile=lockfile,
-        files_preserve=[watched_file_handler.stream],
-        stderr=watched_file_handler.stream,
-        stdout=watched_file_handler.stream)
+
+    parser = get_common_argparser(description, logfile)
+    parser.add_argument("--purge", dest="purge", action="store_true")
+
+    options = parser.parse_args()
+
+    settings = read_settings(conffile)
     if options.purge:
         settings["purge"] = True
+
+    context = setup_daemon(options, settings, pidfile)
     with context:
         logging.info("Running LAVA PDU Listener %s %s %d."
                      % (logfile,
-                        daemon_settings['hostname'],
-                        daemon_settings['port']))
+                        settings['daemon']['hostname'],
+                        settings['daemon']['port']))
         ListenerServer(settings).start()

--- a/lavapdu-runner
+++ b/lavapdu-runner
@@ -19,18 +19,10 @@
 #  MA 02110-1301, USA.
 
 import logging
-import os
-import sys
-import optparse
-from lavapdu.shared import get_daemon_logger
 from lavapdu.shared import read_settings
+from lavapdu.shared import get_common_argparser
+from lavapdu.shared import setup_daemon
 import lavapdu.runnermaster as runnermaster
-
-import daemon
-try:
-    import daemon.pidlockfile as pidlockfile
-except ImportError:
-    from lockfile import pidlockfile
 
 from lavapdu.pdurunner import PDURunner
 
@@ -39,35 +31,12 @@ if __name__ == '__main__':
     pidfile = "/var/run/lavapdu-runner.pid"
     logfile = "/var/log/lavapdu-runner.log"
     conffile = "/etc/lavapdu/lavapdu.conf"
+
+    parser = get_common_argparser(None, logfile)
+    options = parser.parse_args()
+
     settings = read_settings(conffile)
-    level = logging.DEBUG
-    daemon_settings = settings["daemon"]
-    if daemon_settings["logging_level"] == "DEBUG":
-        level = logging.DEBUG
-    if daemon_settings["logging_level"] == "WARNING":
-        level = logging.WARNING
-    if daemon_settings["logging_level"] == "ERROR":
-        level = logging.ERROR
-    if daemon_settings["logging_level"] == "INFO":
-        level = logging.INFO
-    client_logger, watched_file_handler = get_daemon_logger(
-        logfile,
-        loglevel=level,
-        log_format='%(asctime)s:%(levelname)s:%(name)s:%(message)s')
-    if isinstance(client_logger, Exception):
-        print("Fatal error creating client_logger: " + str(client_logger))
-        sys.exit(os.EX_OSERR)
-    # noinspection PyArgumentList
-    lockfile = pidlockfile.PIDLockFile(pidfile)
-    if lockfile.is_locked():
-        logging.error("PIDFile %s already locked" % pidfile)
-        sys.exit(os.EX_OSERR)
-    context = daemon.DaemonContext(
-        detach_process=True,
-        working_directory=os.getcwd(),
-        pidfile=lockfile,
-        files_preserve=[watched_file_handler.stream],
-        stderr=watched_file_handler.stream,
-        stdout=watched_file_handler.stream)
+
+    context = setup_daemon(options, settings, pidfile)
     with context:
-        runnermaster.start_em_up(settings, pidfile)
+        runnermaster.start_em_up(settings)

--- a/lavapdu-runner
+++ b/lavapdu-runner
@@ -57,9 +57,15 @@ if __name__ == '__main__':
     if isinstance(client_logger, Exception):
         print("Fatal error creating client_logger: " + str(client_logger))
         sys.exit(os.EX_OSERR)
+    # noinspection PyArgumentList
+    lockfile = pidlockfile.PIDLockFile(pidfile)
+    if lockfile.is_locked():
+        logging.error("PIDFile %s already locked" % pidfile)
+        sys.exit(os.EX_OSERR)
     context = daemon.DaemonContext(
         detach_process=True,
         working_directory=os.getcwd(),
+        pidfile=lockfile,
         files_preserve=[watched_file_handler.stream],
         stderr=watched_file_handler.stream,
         stdout=watched_file_handler.stream)

--- a/lavapdu/runnermaster.py
+++ b/lavapdu/runnermaster.py
@@ -37,20 +37,14 @@ def start_runner(config, pdu):
 
 
 def start_em_up(config, pidfile):
-    pid = os.getpid()
-    if os.path.isfile(pidfile):
-        log.error("Pidfile already exists")
-        sys.exit(1)
-    f = open(pidfile, 'w')
-    f.write(str(pid))
-    f.close()
     pdus = pdus_from_config(config)
     for pdu in pdus:
         p = Process(target=start_runner, args=(config, pdu))
         p.start()
         processes.append(p)
     signal.signal(signal.SIGTERM, signal_term_handler)
-
+    for proc in processes:
+        proc.join()
 
 def signal_term_handler(a, b):
     del a, b

--- a/lavapdu/runnermaster.py
+++ b/lavapdu/runnermaster.py
@@ -36,7 +36,7 @@ def start_runner(config, pdu):
     p.run_me()
 
 
-def start_em_up(config, pidfile):
+def start_em_up(config):
     pdus = pdus_from_config(config)
     for pdu in pdus:
         p = Process(target=start_runner, args=(config, pdu))

--- a/lavapdu/shared.py
+++ b/lavapdu/shared.py
@@ -4,6 +4,7 @@ import logging
 import json
 import argparse
 from logging.handlers import WatchedFileHandler
+from logging import StreamHandler
 import daemon
 try:
     import daemon.pidlockfile as pidlockfile
@@ -14,14 +15,17 @@ def get_daemon_logger(filepath, log_format=None, loglevel=logging.INFO):
     logger = logging.getLogger()
     logger.setLevel(loglevel)
     try:
-        watchedhandler = WatchedFileHandler(filepath)
+        if filepath:
+            handler = WatchedFileHandler(filepath)
+        else:
+            handler = StreamHandler()
     except Exception as e:  # pylint: disable=broad-except
         return e
 
-    watchedhandler.setFormatter(logging.Formatter(log_format
-                                                  or '%(asctime)s %(msg)s'))
-    logger.addHandler(watchedhandler)
-    return logger, watchedhandler
+    handler.setFormatter(logging.Formatter(log_format
+                                           or '%(asctime)s %(msg)s'))
+    logger.addHandler(handler)
+    return logger, handler
 
 
 def read_settings(filename):
@@ -49,10 +53,6 @@ def pdus_from_config(data):
 
 def setup_daemon(options, settings, pidfile):
     logfile = options.logfile
-    if not os.path.exists(os.path.dirname(options.logfile)):
-        print "No such directory for specified logfile '%s'" % logfile
-
-    open(logfile, 'w').close()
     level = logging.DEBUG
     daemon_settings = settings["daemon"]
     if daemon_settings["logging_level"] == "DEBUG":
@@ -63,8 +63,8 @@ def setup_daemon(options, settings, pidfile):
         level = logging.ERROR
     if daemon_settings["logging_level"] == "INFO":
         level = logging.INFO
-    client_logger, watched_file_handler = get_daemon_logger(
-        logfile,
+    client_logger, handler = get_daemon_logger(
+        None if options.foreground else logfile,
         loglevel=level,
         log_format='%(asctime)s:%(levelname)s:%(name)s:%(message)s')
     if isinstance(client_logger, Exception):
@@ -76,18 +76,21 @@ def setup_daemon(options, settings, pidfile):
         logging.error("PIDFile %s already locked" % pidfile)
         sys.exit(os.EX_OSERR)
     context = daemon.DaemonContext(
-        detach_process=True,
+        detach_process=not options.foreground,
         working_directory=os.getcwd(),
         pidfile=lockfile,
-        files_preserve=[watched_file_handler.stream],
-        stderr=watched_file_handler.stream,
-        stdout=watched_file_handler.stream)
+        files_preserve=[handler.stream],
+        stderr=handler.stream,
+        stdout=handler.stream)
 
     return context
 
 
 def get_common_argparser(description, logfile):
     parser = argparse.ArgumentParser(description=description)
+    parser.add_argument("--foreground", "-f",
+                        help="Stay in the foreground",
+                        action="store_true", default=False)
     parser.add_argument("--logfile", dest="logfile", action="store",
                         type=str, default=logfile,
                         help="log file [%s]" % logfile)

--- a/lavapdu/shared.py
+++ b/lavapdu/shared.py
@@ -20,7 +20,8 @@ def get_daemon_logger(filepath, log_format=None, loglevel=logging.INFO):
         else:
             handler = StreamHandler()
     except Exception as e:  # pylint: disable=broad-except
-        return e
+        print("Fatal error creating client_logger: " + str(e))
+        sys.exit(os.EX_OSERR)
 
     handler.setFormatter(logging.Formatter(log_format
                                            or '%(asctime)s %(msg)s'))
@@ -67,9 +68,6 @@ def setup_daemon(options, settings, pidfile):
         None if options.foreground else logfile,
         loglevel=level,
         log_format='%(asctime)s:%(levelname)s:%(name)s:%(message)s')
-    if isinstance(client_logger, Exception):
-        print("Fatal error creating client_logger: " + str(client_logger))
-        sys.exit(os.EX_OSERR)
     # noinspection PyArgumentList
     lockfile = pidlockfile.PIDLockFile(pidfile)
     if lockfile.is_locked():


### PR DESCRIPTION
Playing with pdudaemon caused two annoyances.
-  there is no way to run it in the foreground to do quick hack/debug cycles when adding 
  a new pdu driver 
- It directly writes its own logfile rather then using any existing logging infrastructure (so doesn't 
  integrate with journal/syslog, need elevated permissions to create the file in /var/log, needs 
  logrotate assistance to rotate etc)

This pull request fixes the former in the obvious way and the latter by adding an option to log to the journal (which can be further processed via syslog if one wants to)
